### PR TITLE
Modifly Tokenizer

### DIFF
--- a/example/finetune.py
+++ b/example/finetune.py
@@ -53,7 +53,7 @@ model_config = {'bert': BertConfig,
                 'megatron': MegatronBertConfig,
                 'megatron_t5':T5Config}
 
-tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model_path)
+tokenizer = BertTokenizer.from_pretrained(args.pretrained_model_path)
 
 
 def load_data(file_path):

--- a/example/pretraining.py
+++ b/example/pretraining.py
@@ -49,7 +49,7 @@ model_config = {'bert': BertConfig,
                 'roformer': RoFormerConfig,
                 'megatron': MegatronBertConfig}
 
-tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model_path)
+tokenizer = BertTokenizer.from_pretrained(args.pretrained_model_path)
 
 
 def load_data(file_path):


### PR DESCRIPTION
因为目前的模型都是用的BertTokenizer，所以将AutoTokenizer改为BertTokenizer。用AutoTokenizer识别不出config的model _type为megatron-bert的模型的Tokenizer