### PR TITLE
修正默认参数 max_length 的值

### DIFF
--- a/fengshen/examples/ubert/README.md
+++ b/fengshen/examples/ubert/README.md
@@ -68,7 +68,7 @@ for line in result:
 --gpus                        #gpu 的数量
 --check_val_every_n_epoch     #多少次验证一次， 默认 100
 --max_epochs                  #多少个 epochs， 默认 5
---max_length                  #句子最大长度， 默认 512
+--max_length                  #句子最大长度， 默认 128
 --num_labels                  #训练每条样本最多取多少个label，超过则进行随机采样负样本， 默认 10
 ```
 


### PR DESCRIPTION
实际上，在[模型文件](https://github.com/IDEA-CCNL/Fengshenbang-LM/blob/main/fengshen/models/ubert/modeling_ubert.py#L202)中，max_length的默认值设置的事128。