### PR TITLE
为了使用Ubert系列，更新setup限制lightning版本，修改ubert本身在example运行时是None的代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# 本人序
+对于二郎神系列模型Erlangshen-Ubert-110M-Chinese和对应330M的模型，官方的文档example首先有typo错误，是跑不通的，需要修改``UbertPiplines``把``UbertPipelines``（少了一个e），另外通过文档的安装方式也是不行的，由于代码的pytorch lightning写法是1.x的，现在2.x已经不适合了，官方的setup.py没有规定版本，我已经更改。另外还缺少了一些依赖，我也已经在这个repo里面补充。
+
+**小结**
+1. 修改fengshen库的setup.py，规定version，若按照原setup会报错
+2. 修改readme的example，修改typo（我的2h没了，实在是没发觉是文档少了个字母）在repo[https://github.com/Yonggie/Fengshenbang-doc](https://github.com/Yonggie/Fengshenbang-doc)里面
+
+以下是他们官方的话语
+=======================
+
+
 [**中文**](./README.md) | [**English**](./README_en.md)
 
 <p align="center">

--- a/fengshen/models/ubert/modeling_ubert.py
+++ b/fengshen/models/ubert/modeling_ubert.py
@@ -706,7 +706,7 @@ class UbertPipelines:
 
         self.args = args
         self.checkpoint_callback = TaskModelCheckpoint(args).callbacks
-        self.logger = loggers.TensorBoardLogger(save_dir=args.default_root_dir)
+        self.logger = loggers.TensorBoardLogger(save_dir='./') # args.default_root_dir
         self.trainer = pl.Trainer.from_argparse_args(args,
                                                      logger=self.logger,
                                                      callbacks=[self.checkpoint_callback])

--- a/fengshen/models/ubert/modeling_ubert.py
+++ b/fengshen/models/ubert/modeling_ubert.py
@@ -708,6 +708,8 @@ class UbertPipelines:
         self.checkpoint_callback = TaskModelCheckpoint(args).callbacks
         self.logger = loggers.TensorBoardLogger(save_dir='./') # args.default_root_dir
         self.trainer = pl.Trainer.from_argparse_args(args,
+                                                     accelerator='gpu',
+                                                     devices=0, # 这个参数可以先同时删掉accelerator和gpu，看他的提示然后修改。
                                                      logger=self.logger,
                                                      callbacks=[self.checkpoint_callback])
 

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
+        'tensorboard',
         'transformers >= 4.17.0',
         'datasets >= 2.0.0',
-        'pytorch_lightning >= 1.5.10',
+        'pytorch_lightning <= 1.9.4',
         'deepspeed >= 0.5.10',
         'jieba-fast >= 0.53',
         'jieba >= 0.40.0',


### PR DESCRIPTION
args.default_root_dir默认是``None``，不改example跑不了。反正要么改example要么改这里，其对应的exmaple也没有用到logger，这里写什么都无所谓。

setup如果不改，Ubert那两个模型会下载lightning2.x，代码已经在lightning2.x下已经跑不了了。